### PR TITLE
Configuration file updated

### DIFF
--- a/iamsync.py
+++ b/iamsync.py
@@ -25,7 +25,7 @@ parser.add_argument(
     "-c",
     "--config",
     type=str,
-    default="iam.yml",
+    default="/etc/iamsync.yml",
     required=False,
     help="Path to configuration file",
 )

--- a/playbook.yml
+++ b/playbook.yml
@@ -36,7 +36,7 @@
   
   - name: Create iamsync config
     copy:
-      dest: '/root/iam.yml'
+      dest: '/etc/iamsync.yml'
       owner: 'root'
       group: 'root'
       mode: '0600'


### PR DESCRIPTION
The name and location of the default iamsync.py configuration file has been updated, and is now expected to be found in the following location: `/etc/iamsync.yml`.